### PR TITLE
 author-nameのtypeでモデレーターを判断する

### DIFF
--- a/YouTubeCommentNotifier.user.js
+++ b/YouTubeCommentNotifier.user.js
@@ -198,7 +198,6 @@ async function main() {
 
   const toMessage = chatItem => {
     const nameElem  = chatItem.querySelector('#author-name');
-    const badgeElem = chatItem.querySelector('yt-live-chat-author-badge-renderer');
     const iconElem  = chatItem.querySelector('yt-img-shadow > img#img');
     const bodyElem  = chatItem.querySelector('#message');
 
@@ -206,7 +205,7 @@ async function main() {
       const name      = nameElem.textContent;
       const iconUrl   = iconElem.src;
       const body      = bodyElem.textContent;
-      const badgeType = badgeElem && badgeElem.getAttribute('type'); // nullable
+      const badgeType = nameElem.getAttribute('type');
 
       return new Message(name, iconUrl, badgeType, body);
     }


### PR DESCRIPTION
Fix #1 

yt-live-chat-author-badge-rendererはノードが残ることがあり、モデレーターと誤検出されてしまう。
#author-nameにもtype属性があり、ここにもモデレーターの情報があるのでこれを使用すると誤検出されなくなった
